### PR TITLE
add _urlChanged observer to reconnect on url change

### DIFF
--- a/krumponent-sprocket-data.html
+++ b/krumponent-sprocket-data.html
@@ -67,6 +67,7 @@ Component for Sprocket data subscription
       },
       observers: [
         '_streamChanged(sprocketUser, sprocketSecret, sprocketStream)',
+        '_urlChanged(sprocketUrl)',
         // '_statusChanged(_status)'
       ],
 
@@ -96,6 +97,15 @@ Component for Sprocket data subscription
 
           
         }
+      },
+      /** Reset socket and reconnect on change to url. */
+      _urlChanged: function(sprocketUrl) {
+        if(this._socket) {
+          this._cleanup();
+          this._socket.destroy();
+          this.set('_socket', undefined);
+        }
+        this.connect();
       },
       /** Initiate connection to Sprocket. Will always be called by detached. */
       disconnect: function(){
@@ -143,6 +153,7 @@ Component for Sprocket data subscription
           this._log(message);
           this.set('data', message);
         }.bind(this));
+
         
           
       },

--- a/krumponent-sprocket-data.html
+++ b/krumponent-sprocket-data.html
@@ -98,8 +98,14 @@ Component for Sprocket data subscription
           
         }
       },
-      /** Reset socket and reconnect on change to url. */
+      /** If the url changes, we must reconnect for the socket to use the new url. */
       _urlChanged: function(sprocketUrl) {
+        if(this.auto)
+          this.reconnect();
+      },
+      /** Cleans up the socket and then reconnects. */
+      reconnect: function() {
+        // Cleanup old socket.
         if(this._socket) {
           this._cleanup();
           this._socket.destroy();


### PR DESCRIPTION
This is primarily so `krumponent-sprocket-data` elements can be made and added to the DOM programatically.

For example:

```
var feedElement = document.createElement('krumponent-sprocket-data');
feedElement.set('sprocketUrl', url);
Polymer.dom(this).appendChild(feedElement);
```

doesn't work because the `sprocketUrl` variable does not get initialized in time and the socket attempts to connect with the default url of `/`.